### PR TITLE
remove single/double quotes from pg_version

### DIFF
--- a/aws-pgbench-postgresql/execute/post-processing.py
+++ b/aws-pgbench-postgresql/execute/post-processing.py
@@ -22,7 +22,7 @@ def main():
     max_tps = 0
 
     for pg_version in pg_versions:
-        pg_version = pg_version.replace("\'", '').replace('\"', '')
+        pg_version = pg_version.strip('\'').strip('\"')
         data = pd.read_csv(
             '%s/pgbench_data/pgbench-tps-%s.csv' % (dir_path, pg_version)
         )

--- a/aws-pgbench-postgresql/execute/post-processing.py
+++ b/aws-pgbench-postgresql/execute/post-processing.py
@@ -22,6 +22,7 @@ def main():
     max_tps = 0
 
     for pg_version in pg_versions:
+        pg_version = pg_version.replace("\'", '').replace('\"', '')
         data = pd.read_csv(
             '%s/pgbench_data/pgbench-tps-%s.csv' % (dir_path, pg_version)
         )


### PR DESCRIPTION
Fixes `FileNotFoundError` due to `pg_version` containing single quotes `'` when used in the path string