### PR TITLE
edb-terraform breaking-change fixes

### DIFF
--- a/aws-dbt2-aurora/execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-aurora/execute/playbook-dbt2-run.yml
@@ -28,7 +28,11 @@
       ansible.builtin.command:
         cmd: >-
           dig
-            {{ infra.servers.aurora.dbt2.address }}
+          {% if infra.servers.aurora.dbt2.public_ip != "null" %}
+            {{ infra.servers.aurora.dbt2.public_ip }}
+          {% else %}
+            {{ infra.servers.aurora.dbt2.private_ip }}
+          {% endif %}
             +short
       register: address
 

--- a/aws-dbt2-aurora/execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-aurora/execute/playbook-dbt2-run.yml
@@ -28,7 +28,7 @@
       ansible.builtin.command:
         cmd: >-
           dig
-          {% if infra.servers.aurora.dbt2.public_ip != "null" %}
+          {% if infra.servers.aurora.dbt2.public_ip %}
             {{ infra.servers.aurora.dbt2.public_ip }}
           {% else %}
             {{ infra.servers.aurora.dbt2.private_ip }}

--- a/aws-dbt2-aurora/infrastructure.yml
+++ b/aws-dbt2-aurora/infrastructure.yml
@@ -1,5 +1,5 @@
-cluster_name: DBT2-Aurora
 aws:
+  cluster_name: DBT2-Aurora
   ssh_user: rocky
   operating_system:
     name: Rocky-8-ec2-8.6-20220515.0.x86_64
@@ -7,7 +7,7 @@ aws:
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16
-      azs:
+      zones:
         us-east-1b: 10.0.0.0/24
         us-east-1c: 10.0.1.0/24
       service_ports:
@@ -28,7 +28,7 @@ aws:
     dbt2-driver:
       type: dbt2-driver
       region: us-east-1
-      az: us-east-1b
+      zone: us-east-1b
       instance_type: c5.9xlarge
       volume:
         type: gp2
@@ -39,7 +39,7 @@ aws:
   aurora:
     dbt2:
       region: us-east-1
-      azs:
+      zones:
       - us-east-1b
       - us-east-1c
       count: 1

--- a/aws-dbt2-aurora/prepare/playbook-dbt2-build-db.yml
+++ b/aws-dbt2-aurora/prepare/playbook-dbt2-build-db.yml
@@ -22,8 +22,7 @@
         DBT2PGDATA: /tmp
         DBT2DBNAME: "{{ infra.servers.aurora.dbt2.dbname }}"
         PGPASSWORD: "{{ pg_password }}"
-        PGHOST: "{{ infra.servers.aurora.dbt2.public_ip }}"
-        "{% if infra.servers.aurora.dbt2.public_ip != "null" %}{{ infra.servers.aurora.dbt2.public_ip }}{% else %}{{ infra.servers.aurora.dbt2.private_ip }}{% endif %}"
+        PGHOST: "{% if infra.servers.aurora.dbt2.public_ip %}{{ infra.servers.aurora.dbt2.public_ip }}{% else %}{{ infra.servers.aurora.dbt2.private_ip }}{% endif %}"
       become_user: "{{ pg_owner }}"
       async: 180000
       poll: 60

--- a/aws-dbt2-aurora/prepare/playbook-dbt2-build-db.yml
+++ b/aws-dbt2-aurora/prepare/playbook-dbt2-build-db.yml
@@ -22,7 +22,8 @@
         DBT2PGDATA: /tmp
         DBT2DBNAME: "{{ infra.servers.aurora.dbt2.dbname }}"
         PGPASSWORD: "{{ pg_password }}"
-        PGHOST: "{{ infra.servers.aurora.dbt2.address }}"
+        PGHOST: "{{ infra.servers.aurora.dbt2.public_ip }}"
+        "{% if infra.servers.aurora.dbt2.public_ip != "null" %}{{ infra.servers.aurora.dbt2.public_ip }}{% else %}{{ infra.servers.aurora.dbt2.private_ip }}{% endif %}"
       become_user: "{{ pg_owner }}"
       async: 180000
       poll: 60

--- a/aws-dbt2-aurora/provision/run.sh
+++ b/aws-dbt2-aurora/provision/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eux
 
-edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml --validate
+edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml
 cd ${TERRAFORM_PROJECT_PATH}
+terraform init
 terraform apply -auto-approve

--- a/aws-dbt2-aurora/provision/run.sh
+++ b/aws-dbt2-aurora/provision/run.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -eux
 
-edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml
+edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml --validate
 cd ${TERRAFORM_PROJECT_PATH}
-terraform init
-terraform apply -var-file=./terraform_vars.json -auto-approve
+terraform apply -auto-approve

--- a/aws-dbt2-aurora/unprovision/run.sh
+++ b/aws-dbt2-aurora/unprovision/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
 cd ${TERRAFORM_PROJECT_PATH}
-terraform destroy -var-file=./terraform_vars.json -auto-approve
+terraform destroy -auto-approve

--- a/aws-dbt2-biganimal/execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-biganimal/execute/playbook-dbt2-run.yml
@@ -33,7 +33,7 @@
       ansible.builtin.command:
         cmd: >-
           dig
-          {% if infra.servers.databases.dbt2.public_ip != "null" %}
+          {% if infra.servers.databases.dbt2.public_ip %}
             {{ infra.servers.databases.dbt2.public_ip }}
           {% else %}
             {{ infra.servers.databases.dbt2.private_ip }}

--- a/aws-dbt2-biganimal/execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-biganimal/execute/playbook-dbt2-run.yml
@@ -33,7 +33,11 @@
       ansible.builtin.command:
         cmd: >-
           dig
-            {{ infra.servers.databases.dbt2.address }}
+          {% if infra.servers.databases.dbt2.public_ip != "null" %}
+            {{ infra.servers.databases.dbt2.public_ip }}
+          {% else %}
+            {{ infra.servers.databases.dbt2.private_ip }}
+          {% endif %}
             +short
       register: address
 

--- a/aws-dbt2-biganimal/infrastructure.yml
+++ b/aws-dbt2-biganimal/infrastructure.yml
@@ -1,5 +1,5 @@
-cluster_name: DBT2-BigAnimal
 aws:
+  cluster_name: DBT2-BigAnimal
   ssh_user: rocky
   operating_system:
     name: Rocky-8-ec2-8.6-20220515.0.x86_64
@@ -7,7 +7,7 @@ aws:
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16
-      azs:
+      zones:
         us-east-1b: 10.0.0.0/24
         us-east-1c: 10.0.1.0/24
       service_ports:
@@ -28,7 +28,7 @@ aws:
     dbt2-driver:
       type: dbt2-driver
       region: us-east-1
-      az: us-east-1b
+      zone: us-east-1b
       instance_type: c5.9xlarge
       volume:
         type: gp2

--- a/aws-dbt2-biganimal/prepare/playbook-dbt2-build-db.yml
+++ b/aws-dbt2-biganimal/prepare/playbook-dbt2-build-db.yml
@@ -22,7 +22,7 @@
         DBT2PGDATA: /tmp
         DBT2DBNAME: "{{ infra.servers.databases.dbt2.dbname }}"
         PGPASSWORD: "{{ pg_password }}"
-        PGHOST: "{{ infra.servers.databases.dbt2.address }}"
+        PGHOST: "{% if infra.servers.databases.dbt2.public_ip != "null" %}{{ infra.servers.databases.dbt2.public_ip }}{% else %}{{ infra.servers.databases.dbt2.private_ip }}{% endif %}"
       become_user: "{{ pg_owner }}"
       async: 180000
       poll: 60

--- a/aws-dbt2-biganimal/prepare/playbook-dbt2-build-db.yml
+++ b/aws-dbt2-biganimal/prepare/playbook-dbt2-build-db.yml
@@ -22,7 +22,7 @@
         DBT2PGDATA: /tmp
         DBT2DBNAME: "{{ infra.servers.databases.dbt2.dbname }}"
         PGPASSWORD: "{{ pg_password }}"
-        PGHOST: "{% if infra.servers.databases.dbt2.public_ip != "null" %}{{ infra.servers.databases.dbt2.public_ip }}{% else %}{{ infra.servers.databases.dbt2.private_ip }}{% endif %}"
+        PGHOST: "{% if infra.servers.databases.dbt2.public_ip %}{{ infra.servers.databases.dbt2.public_ip }}{% else %}{{ infra.servers.databases.dbt2.private_ip }}{% endif %}"
       become_user: "{{ pg_owner }}"
       async: 180000
       poll: 60

--- a/aws-dbt2-biganimal/provision/run.sh
+++ b/aws-dbt2-biganimal/provision/run.sh
@@ -6,8 +6,9 @@ RUNDIR=$(dirname "$RUNDIR")
 # We need the absolute path of $TERRAFORM_PROJECT_PATH in this script.
 TERRAFORM_PROJECT_PATH=$(readlink -f "${TERRAFORM_PROJECT_PATH}")
 
-edb-terraform "${TERRAFORM_PROJECT_PATH}" ../infrastructure.yml --validate
+edb-terraform "${TERRAFORM_PROJECT_PATH}" ../infrastructure.yml
 cd "${TERRAFORM_PROJECT_PATH}"
+terraform init
 terraform apply -auto-approve
 
 BIGANIMALINFRAFILE="${TERRAFORM_PROJECT_PATH}/ba-infrastructure.yml"

--- a/aws-dbt2-biganimal/provision/run.sh
+++ b/aws-dbt2-biganimal/provision/run.sh
@@ -6,10 +6,9 @@ RUNDIR=$(dirname "$RUNDIR")
 # We need the absolute path of $TERRAFORM_PROJECT_PATH in this script.
 TERRAFORM_PROJECT_PATH=$(readlink -f "${TERRAFORM_PROJECT_PATH}")
 
-edb-terraform "${TERRAFORM_PROJECT_PATH}" ../infrastructure.yml
+edb-terraform "${TERRAFORM_PROJECT_PATH}" ../infrastructure.yml --validate
 cd "${TERRAFORM_PROJECT_PATH}"
-terraform init
-terraform apply -var-file=./terraform_vars.json -auto-approve
+terraform apply -auto-approve
 
 BIGANIMALINFRAFILE="${TERRAFORM_PROJECT_PATH}/ba-infrastructure.yml"
 

--- a/aws-dbt2-biganimal/unprovision/run.sh
+++ b/aws-dbt2-biganimal/unprovision/run.sh
@@ -4,7 +4,7 @@
 TERRAFORM_PROJECT_PATH=$(readlink -f "${TERRAFORM_PROJECT_PATH}")
 
 cd "${TERRAFORM_PROJECT_PATH}"
-terraform destroy -var-file=./terraform_vars.json -auto-approve
+terraform destroy -auto-approve
 
 BIGANIMALIDFILE="${TERRAFORM_PROJECT_PATH}/biganimal-id"
 BAID=$(<"$BIGANIMALIDFILE")

--- a/aws-dbt2-rds/execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-rds/execute/playbook-dbt2-run.yml
@@ -28,7 +28,11 @@
       ansible.builtin.command:
         cmd: >-
           dig
-            {{ infra.servers.databases.dbt2.address }}
+          {% if infra.servers.databases.dbt2.public_ip != "null" %}
+            {{ infra.servers.databases.dbt2.public_ip }}
+          {% else %}
+            {{ infra.servers.databases.dbt2.private_ip }}
+          {% endif %}
             +short
       register: address
 

--- a/aws-dbt2-rds/execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-rds/execute/playbook-dbt2-run.yml
@@ -28,7 +28,7 @@
       ansible.builtin.command:
         cmd: >-
           dig
-          {% if infra.servers.databases.dbt2.public_ip != "null" %}
+          {% if infra.servers.databases.dbt2.public_ip %}
             {{ infra.servers.databases.dbt2.public_ip }}
           {% else %}
             {{ infra.servers.databases.dbt2.private_ip }}

--- a/aws-dbt2-rds/infrastructure.yml
+++ b/aws-dbt2-rds/infrastructure.yml
@@ -1,5 +1,5 @@
-cluster_name: DBT2-RDS
 aws:
+  cluster_name: DBT2-RDS
   ssh_user: rocky
   operating_system:
     name: Rocky-8-ec2-8.6-20220515.0.x86_64
@@ -7,7 +7,7 @@ aws:
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16
-      azs:
+      zones:
         us-east-1b: 10.0.0.0/24
         us-east-1c: 10.0.1.0/24
       service_ports:
@@ -28,7 +28,7 @@ aws:
     dbt2-driver:
       type: dbt2-driver
       region: us-east-1
-      az: us-east-1b
+      zone: us-east-1b
       instance_type: c5.9xlarge
       volume:
         type: gp2

--- a/aws-dbt2-rds/prepare/playbook-dbt2-build-db.yml
+++ b/aws-dbt2-rds/prepare/playbook-dbt2-build-db.yml
@@ -22,7 +22,7 @@
         DBT2PGDATA: /tmp
         DBT2DBNAME: "{{ infra.servers.databases.dbt2.dbname }}"
         PGPASSWORD: "{{ pg_password }}"
-        PGHOST: "{{ infra.servers.databases.dbt2.address }}"
+        PGHOST: "{% if infra.servers.databases.dbt2.public_ip != "null" %}{{ infra.servers.databases.dbt2.public_ip }}{% else %}{{ infra.servers.databases.dbt2.private_ip }}{% endif %}"
       become_user: "{{ pg_owner }}"
       async: 180000
       poll: 60

--- a/aws-dbt2-rds/prepare/playbook-dbt2-build-db.yml
+++ b/aws-dbt2-rds/prepare/playbook-dbt2-build-db.yml
@@ -22,7 +22,7 @@
         DBT2PGDATA: /tmp
         DBT2DBNAME: "{{ infra.servers.databases.dbt2.dbname }}"
         PGPASSWORD: "{{ pg_password }}"
-        PGHOST: "{% if infra.servers.databases.dbt2.public_ip != "null" %}{{ infra.servers.databases.dbt2.public_ip }}{% else %}{{ infra.servers.databases.dbt2.private_ip }}{% endif %}"
+        PGHOST: "{% if infra.servers.databases.dbt2.public_ip %}{{ infra.servers.databases.dbt2.public_ip }}{% else %}{{ infra.servers.databases.dbt2.private_ip }}{% endif %}"
       become_user: "{{ pg_owner }}"
       async: 180000
       poll: 60

--- a/aws-dbt2-rds/provision/run.sh
+++ b/aws-dbt2-rds/provision/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eux
 
-edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml --validate
+edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml
 cd ${TERRAFORM_PROJECT_PATH}
+terraform init
 terraform apply -auto-approve

--- a/aws-dbt2-rds/provision/run.sh
+++ b/aws-dbt2-rds/provision/run.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -eux
 
-edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml
+edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml --validate
 cd ${TERRAFORM_PROJECT_PATH}
-terraform init
-terraform apply -var-file=./terraform_vars.json -auto-approve
+terraform apply -auto-approve

--- a/aws-dbt2-rds/unprovision/run.sh
+++ b/aws-dbt2-rds/unprovision/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
 cd ${TERRAFORM_PROJECT_PATH}
-terraform destroy -var-file=./terraform_vars.json -auto-approve
+terraform destroy -auto-approve

--- a/aws-pgbench-postgresql/infrastructure.yml
+++ b/aws-pgbench-postgresql/infrastructure.yml
@@ -1,5 +1,5 @@
-cluster_name: pgbench-postgresql
 aws:
+  cluster_name: pgbench-postgresql
   ssh_user: rocky
   operating_system:
     name: Rocky-8-ec2-8.6-20220515.0.x86_64
@@ -7,7 +7,7 @@ aws:
   regions:
     us-east-1:
       cidr_block: 10.0.0.0/16
-      azs:
+      zones:
         us-east-1b: 10.0.0.0/24
       service_ports:
         - port: 22
@@ -21,7 +21,7 @@ aws:
     postgres1:
       type: primary
       region: us-east-1
-      az: us-east-1b
+      zone: us-east-1b
       instance_type: c5d.18xlarge
       volume:
         type: gp2

--- a/aws-pgbench-postgresql/provision/run.sh
+++ b/aws-pgbench-postgresql/provision/run.sh
@@ -4,4 +4,5 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 edb-terraform ${TERRAFORM_PROJECT_PATH} ${SCRIPT_DIR}/../infrastructure.yml
 cd ${TERRAFORM_PROJECT_PATH}
+terraform init
 terraform apply -auto-approve

--- a/aws-pgbench-postgresql/provision/run.sh
+++ b/aws-pgbench-postgresql/provision/run.sh
@@ -4,5 +4,4 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 edb-terraform ${TERRAFORM_PROJECT_PATH} ${SCRIPT_DIR}/../infrastructure.yml
 cd ${TERRAFORM_PROJECT_PATH}
-terraform init
-terraform apply -var-file=./terraform_vars.json -auto-approve
+terraform apply -auto-approve

--- a/aws-pgbench-postgresql/unprovision/run.sh
+++ b/aws-pgbench-postgresql/unprovision/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
 cd ${TERRAFORM_PROJECT_PATH}
-terraform destroy -var-file=./terraform_vars.json -auto-approve
+terraform destroy -auto-approve

--- a/aws-psr-3-nodes/infrastructure.yml
+++ b/aws-psr-3-nodes/infrastructure.yml
@@ -1,5 +1,5 @@
-cluster_name: MC-PSR-EFM-Test
 aws:
+  cluster_name: MC-PSR-EFM-Test
   ssh_user: cloud-user
   #ssh_user: centos
   operating_system:
@@ -10,7 +10,7 @@ aws:
   regions:
     us-east-2:
       cidr_block: 10.0.0.0/16
-      azs:
+      zones:
         us-east-2b: 10.0.0.0/24
       service_ports:
         - port: 22
@@ -42,7 +42,7 @@ aws:
     psr-client-1:
       type: client
       region: us-east-2
-      az: us-east-2b
+      zone: us-east-2b
       instance_type: c5.2xlarge
       volume:
         type: gp2
@@ -51,7 +51,7 @@ aws:
     psr-proxy-1:
       type: proxy
       region: us-east-2
-      az: us-east-2b
+      zone: us-east-2b
       instance_type: c5.2xlarge
       volume:
         type: gp2
@@ -60,7 +60,7 @@ aws:
     psr-pg-1:
       type: primary
       region: us-east-2
-      az: us-east-2b
+      zone: us-east-2b
       instance_type: r5.2xlarge
       volume:
         type: gp2
@@ -80,7 +80,7 @@ aws:
     psr-pg-2:
       type: standby
       region: us-east-2
-      az: us-east-2b
+      zone: us-east-2b
       instance_type: r5.2xlarge
       volume:
         type: gp2
@@ -100,7 +100,7 @@ aws:
     psr-pg-3:
       type: standby
       region: us-east-2
-      az: us-east-2b
+      zone: us-east-2b
       instance_type: r5.2xlarge
       volume:
         type: gp2

--- a/aws-psr-3-nodes/provision/run.sh
+++ b/aws-psr-3-nodes/provision/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eux
 
-edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml --validate
+edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml
 cd ${TERRAFORM_PROJECT_PATH}
+terraform init
 terraform apply -auto-approve

--- a/aws-psr-3-nodes/provision/run.sh
+++ b/aws-psr-3-nodes/provision/run.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -eux
 
-edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml
+edb-terraform ${TERRAFORM_PROJECT_PATH} ../infrastructure.yml --validate
 cd ${TERRAFORM_PROJECT_PATH}
-terraform init
-terraform apply -var-file=./terraform_vars.json -auto-approve
+terraform apply -auto-approve

--- a/aws-psr-3-nodes/unprovision/run.sh
+++ b/aws-psr-3-nodes/unprovision/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
 cd ${TERRAFORM_PROJECT_PATH}
-terraform destroy -var-file=./terraform_vars.json -auto-approve
+terraform destroy -auto-approve

--- a/aws-tpcc-tde/provision/run.sh
+++ b/aws-tpcc-tde/provision/run.sh
@@ -5,4 +5,4 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 edb-terraform ${TERRAFORM_PROJECT_PATH} ${SCRIPT_DIR}/../infrastructure.yml
 cd ${TERRAFORM_PROJECT_PATH}
 terraform init
-terraform apply -var-file=./terraform_vars.json -auto-approve
+terraform apply -auto-approve

--- a/aws-tpcc-tde/unprovision/run.sh
+++ b/aws-tpcc-tde/unprovision/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
 cd ${TERRAFORM_PROJECT_PATH}
-terraform destroy -var-file=./terraform_vars.json -auto-approve
+terraform destroy -auto-approve


### PR DESCRIPTION
EDB-Terraform will have breaking changes: https://github.com/EnterpriseDB/edb-terraform/pull/20
* `az` and `azs` changed to `zone` and `zones`
* `cluster_name` moved under cloud-service-provider key in the yaml file.
* `terraform >= 1.3.6` required
* `-var-file=` is no longer needed since edb-terraform now creates it in the file name `terraform.tfvars.json` which terraform automatically picks up