### PR TITLE
Fix HammerDB scripts

### DIFF
--- a/aws-tpcc-tde/execute/files/exec-hdb-rampup.sh
+++ b/aws-tpcc-tde/execute/files/exec-hdb-rampup.sh
@@ -50,6 +50,8 @@ diset tpcc pg_count_ware ${WAREHOUSE}
 diset tpcc pg_driver timed
 diset tpcc pg_duration ${DURATION}
 diset tpcc pg_rampup ${RAMPUP}
+diset tpcc pg_allwarehouse true
+diset tpcc pg_num_vu ${c}
 vuset logtotemp 1
 loadscript
 vuset vu ${c}

--- a/aws-tpcc-tde/execute/templates/runner.tcl.j2
+++ b/aws-tpcc-tde/execute/templates/runner.tcl.j2
@@ -26,6 +26,8 @@ diset tpcc pg_driver timed
 diset tpcc pg_duration {{ tpcc_duration }}
 diset tpcc pg_rampup {{ tpcc_rampup }}
 diset tpcc pg_timeprofile false
+diset tpcc pg_allwarehouse true
+diset tpcc pg_num_vu {{ tpcc_vusers }}
 vuset logtotemp 1
 loadscript
 vuset vu {{ tpcc_vusers }}


### PR DESCRIPTION
By default, HammerDB does not target all the warehouses, only one. Which make the TPC-C benchmark useless...