### PR TITLE
Add manual steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# EDB Benchmarking Automation Center
 ## Welcome to the edb-benchmarks repository!
 
 This repository contains workflows for benchmarks that have been previously developed and are ready for a pre-built execution via the Buildbot User Interface.
@@ -35,7 +34,7 @@ Execution of a benchmark is accomplished by following the steps below
 
 Each benchmark should follow the directory structure listed below with a numberic prefix and a step name:
 
-- `00_validate` - Validates the parameters selected for the benchmark execution. **If the validation fails the entire benchmark fails.**
+- `00_validate` - Validates the parameters selected for the benchmark execution. **If the validation fails, the entire benchmark fails.**
 - `01_provision` - Provisions the infrastructure required for executing the benchmark
 - `02_deploy` - Sets up and configures the provisioned infrastructure
 - `03_prepare` - Prepares and sets up the benchmark execution
@@ -44,13 +43,6 @@ Each benchmark should follow the directory structure listed below with a numberi
 - `06_unprovision` - Destroys the previously provisioned infrastructure
 
 **Each directory contains a `run.sh` script file that executes the ansible playbooks required for the benchmark**
-
-** For development, you can use the run_benchmark.sh script to assist in running and debugging each step.
-** Stored in repo with execuation bit on.
-```shell
-./run_benchmark.sh -h
-./run_benchmark.sh -b aws-dbt2-aurora
-```
 
 ### Executing a benchmark by hand
 
@@ -62,27 +54,27 @@ $ git clone https://github.com/EnterpriseDB/edb-benchmarks.git
 
 From the terminal, set environment variables required by the cloud service provider.
 
-If desired, make changes to the type or size of the database by editing the [environment file](environment.sh).
+If desired, make changes to the type or size of the database by editing the environment file: `environment.sh`.
 
-Source the [environment file](environment.sh).
-```console
-# source ../environment.sh
-```
+Source the environment file.
 
-Execute 00_validate/run.sh
+`source <benchmark-directory>/environment.sh`
 
-Execute 01_provision/run.sh
+Execute `<benchmark-directory>/00_validate/run.sh`
+
+Execute `<benchmark-directory>/01_provision/run.sh`
+
 Wait for the 'Apply Complete' success message.
 
-Execute 02_deploy/run.sh
+Execute `<benchmark-directory>/02_deploy/run.sh`
 
 If desired, export additional environment variables manually. 
 
-Execute 03_prepare/run.sh
+Execute `<benchmark-directory>/03_prepare/run.sh`
 
-Execute 04_provision/run.sh
+Execute `<benchmark-directory>/04_provision/run.sh`
 
-When ready to terminate the instance, execute 06_unprovision/run.sh
+When ready to terminate the instance, execute `<benchmark-directory>/06_unprovision/run.sh`
 
 ### Contributing:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ Each benchmark should follow the directory structure listed below with a numberi
 ./run_benchmark.sh -b aws-dbt2-aurora
 ```
 
+### Executing a benchmark by hand
+
+Clone the repo to a local machine.
+
+```console
+$ git clone https://github.com/EnterpriseDB/edb-benchmarks.git
+```
+
+From the terminal, set environment variables required by the cloud service provider.
+
+If desired, make changes to the type or size of the database by editing the [environment file](environment.sh).
+
+Source the [environment file](environment.sh).
+```console
+# source ../environment.sh
+```
+
+Execute 00_validate/run.sh
+
+Execute 01_provision/run.sh
+Wait for the 'Apply Complete' success message.
+
+Execute 02_deploy/run.sh
+
+If desired, export additional environment variables manually. 
+
+Execute 03_prepare/run.sh
+
+Execute 04_provision/run.sh
+
+When ready to terminate the instance, execute 06_unprovision/run.sh
+
 ### Contributing:
 
 We welcome contributions! If you have benchmarks that you would like to share follow the steps below:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Components needed by host:
 - `edb-terraform >= 1.5.1`
 - `AWSCli`
 - `ansible-core`
+- `edb-ansible`
 - `tpaexec`
 
 ### Benchmark folder structure:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Welcome to the edb-benchmarks repository!
 
-This repository contains workflows for benchmarks that have been previously developed and are ready for a pre-built execution via the Buildbot User Interface.
+This repository contains workflows for benchmarks that have been previously developed and are ready for a pre-built execution via the Buildbot User Interface. They can also be executed manually.
 
 ### Getting Started
 
@@ -22,7 +22,7 @@ Components needed by host:
 - `ansible-core`
 - `tpaexec`
 
-### Executing a benchmark
+### Executing a benchmark in Buildbot
 
 Execution of a benchmark is accomplished by following the steps below
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
 ## Welcome to the edb-benchmarks repository!
 
-This repository contains workflows for benchmarks that have been previously developed and are ready for a pre-built execution via the Buildbot User Interface. They can also be executed manually.
+This repository contains workflows for benchmarks that have been previously developed and are ready for execution.
 
 ### Getting Started
 
-To get started Buildbot master and workers are executed through a dedicated Python virtual
-environment.
-
-The following components are installed on the workers:
-- `ansible-core`
-- `terraform`
-- `edb-terraform`
-- `edb-ansible`
-- `biganimal`
-- `tpaexec`
+Benchmarks can be executed through a dedicated Python virtual environment.
 
 Components needed by host:
 - `terraform >= 1.3.6`
@@ -22,24 +13,16 @@ Components needed by host:
 - `ansible-core`
 - `tpaexec`
 
-### Executing a benchmark in Buildbot
-
-Execution of a benchmark is accomplished by following the steps below
-
-- Clicking the `Builders` Link on the left hand navigation
-- Filling all the parameters requested 
-- Executing the `Start build`
-
 ### Benchmark folder structure:
 
-Each benchmark should follow the directory structure listed below with a numberic prefix and a step name:
+Each benchmark should follow the directory structure listed below with a numeric prefix and a step name:
 
 - `00_validate` - Validates the parameters selected for the benchmark execution. **If the validation fails, the entire benchmark fails.**
 - `01_provision` - Provisions the infrastructure required for executing the benchmark
 - `02_deploy` - Sets up and configures the provisioned infrastructure
 - `03_prepare` - Prepares and sets up the benchmark execution
 - `04_execute` - Executes the benchmark
-- `05_push_results` - Upload the results from the benchmark into AWS S3 Bucket
+- `05_push_results` - Uploads the results from the benchmark into AWS S3 Bucket
 - `06_unprovision` - Destroys the previously provisioned infrastructure
 
 **Each directory contains a `run.sh` script file that executes the ansible playbooks required for the benchmark**

--- a/aws-dbt2-aurora/README.md
+++ b/aws-dbt2-aurora/README.md
@@ -3,55 +3,59 @@
 
 AWS DBT2 Aurora is a project that provides benchmark data for DBT2 Aurora on Amazon Web Services (AWS).
 
-### Getting Started
+### Dependencies
 
-To get started Buildbot master and workers are executed through a dedicated Python virtual
-environment.
-
-The following components are installed on the workers:
-- `ansible-core`
-- `terraform`
-- `edb-terraform`
-- `edb-ansible`
-- `biganimal`
-- `tpaexec`
-
-Components needed by host:
 - `terraform >= 1.3.6`
 - `edb-terraform >= 1.0.0`
-- `AWSCli`
-- `ansible-core`
-- `tpaexec`
-
----
-
-Deployment Ansible playbooks are available in the `ansible` directory. These
-playbooks are designed to deploy one buildbot master noder and multiple buildbot
-worker nodes.
-
-Buildbot master and workers are executed through a dedicated Python virtual
-environment.
-
-The following components are installed on the workers:
-- `ansible-core`
-- `terraform`
-- `edb-terraform`
+- `ansible`
 - `edb-ansible`
-- `biganimal`
-- `tpaexec`
+- `AWS CLI`
 
-### Executing a benchmark
+### Getting Started
 
-Execution of a benchmark is accomplished by following the steps below
+This benchmark can be run on a machine with Python installed, or within a Python virtual environment.
 
-- Clicking the `Builders` Link on the left hand navigation
-- Filling all the parameters requested 
-- Executing the `Start build`
+Clone the repo to a local machine.
 
-### Notes:
+```console
+$ git clone https://github.com/EnterpriseDB/edb-benchmarks.git
+```
 
-These are the items to take into account should issues arise:
+### Executing a benchmark by hand
 
-- Should an error within a step of the pipeline for a benchmark fail with an error similar to: "Cannot find the job". Take notice of the step in the workflow and the task. Once you have those items check to see if the `async` and `poll` are commented. **They are currently commented out because they were causing issues with the benchmark**
+Open the terminal from your local machine or from within a virtual environment.
 
+Copy your AWS credentials and paste them into the terminal. They can be found in the Command Line or Programmatic Access menu, under Option 1: Set AWS environment variables (Short-term credentials). This will add the following credentials to your environment as export variables:
 
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN`
+
+From terminal, cd into <your-file-path/edb-benchmarks/aws-dbt2-aurora>.
+
+If desired, make changes to the type or size of the database by editing the [environment file](environment.sh) .
+
+From terminal, cd into 00_validate and run the script:
+
+```console
+$ ./run.sh
+```
+
+cd into 01_provision and run the script.
+
+Wait for the 'Apply Complete' success message.
+
+cd into 02_deploy and run the script.
+
+cd into 03_prepare and run the script. If desired, adjust parameters as needed before running.
+
+Example (change number of warehouses to one):
+
+```console
+$ export DBT2_WAREHOUSE=1
+$ ./run.sh
+```
+
+cd into 04_execute and run the script.
+
+When ready to terminate the instance, cd into 06_unprovision and run the script.

--- a/aws-dbt2-aurora/README.md
+++ b/aws-dbt2-aurora/README.md
@@ -1,4 +1,3 @@
-# EDB Benchmarking Automation Center
 ## AWS DBT2 Aurora
 
 AWS DBT2 Aurora is a project that provides benchmark data for DBT2 Aurora on Amazon Web Services (AWS).

--- a/aws-dbt2-aurora/README.md
+++ b/aws-dbt2-aurora/README.md
@@ -15,47 +15,8 @@ AWS DBT2 Aurora is a project that provides benchmark data for DBT2 Aurora on Ama
 
 This benchmark can be run on a machine with Python installed, or within a Python virtual environment.
 
-Clone the repo to a local machine.
+Instructions for running the benchmark are found in the top level README.
 
-```console
-$ git clone https://github.com/EnterpriseDB/edb-benchmarks.git
-```
+### AWS Credentials
 
-### Executing a benchmark by hand
-
-Open the terminal from your local machine or from within a virtual environment.
-
-Copy your AWS credentials and paste them into the terminal. They can be found in the Command Line or Programmatic Access menu, under Option 1: Set AWS environment variables (Short-term credentials). This will add the following credentials to your environment as export variables:
-
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `AWS_SESSION_TOKEN`
-
-From terminal, cd into <your-file-path/edb-benchmarks/aws-dbt2-aurora>.
-
-If desired, make changes to the type or size of the database by editing the [environment file](environment.sh) .
-
-From terminal, cd into 00_validate and run the script:
-
-```console
-$ ./run.sh
-```
-
-cd into 01_provision and run the script.
-
-Wait for the 'Apply Complete' success message.
-
-cd into 02_deploy and run the script.
-
-cd into 03_prepare and run the script. If desired, adjust parameters as needed before running.
-
-Example (change number of warehouses to one):
-
-```console
-$ export DBT2_WAREHOUSE=1
-$ ./run.sh
-```
-
-cd into 04_execute and run the script.
-
-When ready to terminate the instance, cd into 06_unprovision and run the script.
+See ['How to set environment variables'](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) to determine the credentials needed to provision an instance with AWS.


### PR DESCRIPTION
This PR is to update the aws-dbt2-aurora README so that it is useful for people running this benchmark by hand. The Buildbot info has been removed as I understand that would be documented elsewhere.