### PR TITLE
remove duplicate register parameter

### DIFF
--- a/aws-dbt2-aurora/04_execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-aurora/04_execute/playbook-dbt2-run.yml
@@ -72,7 +72,6 @@
         PGHOST: "{{ address.stdout_lines[-1] }}"
       become: true
       become_user: "{{ pg_owner }}"
-      register: run_workload
       changed_when: false
       register: result
 

--- a/aws-dbt2-biganimal/04_execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-biganimal/04_execute/playbook-dbt2-run.yml
@@ -66,7 +66,6 @@
         PGHOST: "{{ address.stdout_lines[-1] }}"
       become: true
       become_user: "{{ pg_owner }}"
-      register: run_workload
       async: 180000
       poll: 60
       changed_when: false

--- a/aws-dbt2-rds/04_execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-rds/04_execute/playbook-dbt2-run.yml
@@ -77,7 +77,6 @@
         PGHOST: "{{ address.stdout_lines[-1] }}"
       become: true
       become_user: "{{ pg_owner }}"
-      register: run_workload
       changed_when: false
       register: result
 


### PR DESCRIPTION
Within the `04_execute/playbook-dbt2-run.yml` playbooks for `aws-dbt2-rds`, `aws-dbt2-biganimal` and `aws-dbt2-aurora` benchmarks, the `register` parameter was duplicated for the task `Start the dbt2-run-workload`. The parameter that is not used has been removed. 