### PR TITLE
Aws dbt2 rds add postgres error logs

### DIFF
--- a/aws-dbt2-rds/04_execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-rds/04_execute/playbook-dbt2-run.yml
@@ -106,7 +106,7 @@
         module: ansible.builtin.shell
         cmd: >-
           aws rds describe-db-log-files
-          --db-instance-identifier {{ infra.servers.databases.postgres.instance_id }}
+          --db-instance-identifier {{ infra.servers.databases.postgres.resource_id }}
           | jq -r '.DescribeDBLogFiles[] | .LogFileName | sub("error/"; "")'
           > {{ logs_directory }}/postgreslog.txt
       register: result
@@ -116,7 +116,7 @@
         module: ansible.builtin.shell
         cmd: >-
           aws rds download-db-log-file-portion
-          --db-instance-identifier {{ infra.servers.databases.postgres.instance_id }}
+          --db-instance-identifier {{ infra.servers.databases.postgres.resource_id }}
           --log-file-name error/{{ item }}
           --starting-token 0
           > {{ logs_directory }}/{{ item }}.json

--- a/aws-dbt2-rds/04_execute/playbook-dbt2-run.yml
+++ b/aws-dbt2-rds/04_execute/playbook-dbt2-run.yml
@@ -95,6 +95,35 @@
         name: get-aws-cloudwatch-rds-postgres-stats
         tasks_from: get-end-time.yml
 
+    - name: Create logs directory
+      local_action: 
+        module: ansible.builtin.file
+        path: "{{ logs_directory }}"
+        state: directory
+
+    - name: Get Postgres error log names
+      local_action:
+        module: ansible.builtin.shell
+        cmd: >-
+          aws rds describe-db-log-files
+          --db-instance-identifier {{ infra.servers.databases.postgres.instance_id }}
+          | jq -r '.DescribeDBLogFiles[] | .LogFileName | sub("error/"; "")'
+          > {{ logs_directory }}/postgreslog.txt
+      register: result
+
+    - name: Get Postgres error logs
+      local_action:
+        module: ansible.builtin.shell
+        cmd: >-
+          aws rds download-db-log-file-portion
+          --db-instance-identifier {{ infra.servers.databases.postgres.instance_id }}
+          --log-file-name error/{{ item }}
+          --starting-token 0
+          > {{ logs_directory }}/{{ item }}.json
+      loop: 
+        "{{ lookup('file', '{{ logs_directory }}/postgreslog.txt').splitlines() }}"
+      register: result
+
     - name: Workload execution output
       ansible.builtin.debug:
         var: result

--- a/aws-dbt2-rds/04_execute/run.sh
+++ b/aws-dbt2-rds/04_execute/run.sh
@@ -18,6 +18,7 @@ ansible-playbook \
 	-e "terraform_project_path=${TERRAFORM_PROJECT_PATH}" \
 	-e "results_directory=${RESULTS_DIRECTORY}/dbt2-data" \
 	-e "cloudwatch_directory=${RESULTS_DIRECTORY}/cloudwatch" \
+	-e "logs_directory=${RESULTS_DIRECTORY}/logs" \
 	"${SOURCEDIR}/playbook-dbt2-run.yml"
 
 # Copy infrastructure.yml and vars.yml


### PR DESCRIPTION
This update uses the `resource_id` for the postgres log task.