### PR TITLE
Added role to introduce latency on selected hosts.

### DIFF
--- a/aws-psr-3-nodes/03_prepare/playbook-tpcc-build-db.yml
+++ b/aws-psr-3-nodes/03_prepare/playbook-tpcc-build-db.yml
@@ -88,3 +88,19 @@
         name: "{{ pg_service }}"
         state: restarted
       become: true
+
+# This was added specifically to introduce optional latency between Postgres
+# hosts. But we added it as a post-prepare action to include any/all steps
+# that should happen specifically at the end of the benchmark "prepare" step.
+# We're doing this here because this benchmark creates replicas as part of
+# prepare instead of deploy.
+
+- hosts:
+    - primary
+    - standby
+  gather_facts: yes
+
+  roles:
+    - role: post-prepare
+
+

--- a/roles/post-prepare/defaults/main.yml
+++ b/roles/post-prepare/defaults/main.yml
@@ -1,0 +1,1 @@
+latency_ms: 0

--- a/roles/post-prepare/tasks/add-latency.yml
+++ b/roles/post-prepare/tasks/add-latency.yml
@@ -1,0 +1,40 @@
+# Add a certain amount of latency as specified by the latency_ms variable.
+#
+# Use the 'tc' CLI utility to add latency between any systems that include this
+# role. This will allow us to test various scenarios where networks are either
+# slow or separated by varying geographical distances.
+#
+# If the latency_ms variable is defined, this list of tasks should be
+# included as part of the post-prepare series of actions. We do this here
+# because we want it to happen _after_ any primaries or replicas are
+# established, and definitely after benchmark databases are bootstrapped.
+
+---
+- name: Install tc utility on RHEL variants
+  package:
+    name: iproute-tc
+    state: present
+  become: true
+  when:
+    - ansible_distribution in ['RedHat', 'Rocky', 'CentOS', 'OracleLinux', 'AlmaLinux']
+
+- name: Install tc utility on Debian variants
+  package:
+    name: iproute2
+    state: present
+  become: true
+  when:
+    - ansible_distribution in ['Debian', 'Ubuntu']
+
+- name: Add latency to simulate regions
+  shell: |
+    tc qdisc del dev {{ ansible_default_ipv4.interface }} root
+    tc qdisc add dev {{ ansible_default_ipv4.interface }} root handle 1: prio
+    tc qdisc add dev {{ ansible_default_ipv4.interface }} parent 1:3 handle 30: netem latency {{ latency_ms }}ms
+    {% for h in groups['primary']|list + groups['standby']|list -%}
+    {%   if hostvars[h].private_ip != private_ip -%}
+    tc filter add dev {{ ansible_default_ipv4.interface }} protocol ip parent 1:0 prio 3 u32 \
+       match ip dst {{ hostvars[h].private_ip }} flowid 1:3
+    {%   endif -%}
+    {% endfor -%}
+  become: true

--- a/roles/post-prepare/tasks/main.yml
+++ b/roles/post-prepare/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Add latency to primary and standby hosts (optional)
+  include_tasks: add-latency.yml
+  when: 
+    - latency_ms > 0


### PR DESCRIPTION
This adds the post-provision role for general use within all benchmarks. Within this role is the add-latency list of tasks. This task list is only included if the latency_ms variable is non-zero. It is also defined as 0 in the list of default variables to avoid errors from including this module and not setting the variable. It should be a drop-in addition to any benchmark that includes the role for all systems.